### PR TITLE
result not unreachable

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -50,7 +50,7 @@ impl Settings {
                         }
                         Rule::grammar_rule => codes.push(self.format_grammar_rule(pair)),
                         Rule::WHITESPACE => continue,
-                        _ => unreachable!(),
+                        _ => continue,
                     };
                 }
                 let mut last = 0 as usize;

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -126,7 +126,7 @@ impl Settings {
                     println!("Rule:    {:?}", pair.as_rule());
                     println!("Span:    {:?}", pair.as_span());
                     println!("Text:    {}\n", pair.as_str());
-                    unreachable!();
+                    continue;
                 }
             };
         }
@@ -147,7 +147,7 @@ impl Settings {
                     term.push_str(&joiner)
                 }
                 Rule::term => term.push_str(&self.format_term(pair)),
-                _ => unreachable!(),
+                _ => continue,
             };
         }
         code.push(term.clone());
@@ -176,7 +176,7 @@ impl Settings {
                 Rule::repeat_min => code.push_str(&format_repeat_min_max(pair)),
                 Rule::repeat_exact => code.push_str(&format_repeat_min_max(pair)),
                 Rule::repeat_min_max => code.push_str(&format_repeat_min_max(pair)),
-                _ => unreachable!(),
+                _ => continue,
             };
         }
         return code;
@@ -191,7 +191,7 @@ fn format_repeat_exact(pairs: Pair<Rule>) -> String {
             Rule::opening_brace => code.push_str(pair.as_str()),
             Rule::closing_brace => code.push_str(pair.as_str()),
             Rule::number => code.push_str(pair.as_str()),
-            _ => unreachable!(),
+            _ => continue,
         };
     }
     return code;
@@ -206,7 +206,7 @@ fn format_repeat_min_max(pairs: Pair<Rule>) -> String {
             Rule::closing_brace => code.push_str(pair.as_str()),
             Rule::comma => code.push_str(", "),
             Rule::number => code.push_str(pair.as_str()),
-            _ => unreachable!(),
+            _ => continue,
         };
     }
     return code;

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -6,7 +6,6 @@ use pest::{iterators::Pair, Parser};
 use std::{
     fs::{read_to_string, File},
     io::Write,
-    panic,
 };
 
 pub struct Settings {
@@ -32,66 +31,67 @@ impl Settings {
         let r = read_to_string(path_from)?;
         let s = self.format(&r);
         let mut file = File::create(path_to)?;
-        file.write_all(s.as_bytes())?;
-        return Ok(());
+        match s {
+            Ok(s) => {
+                file.write_all(s.as_bytes())?;
+                return Ok(());
+            }
+            Err(_) => return Ok(()),
+        }
     }
-    pub fn format(&self, text: &str) -> String {
-        let result = panic::catch_unwind(|| {
-            if let Ok(pairs) = PestParser::parse(Rule::grammar_rules, text) {
-                let mut code = String::new();
-                let mut codes = vec![];
-                for pair in pairs {
-                    match pair.as_rule() {
-                        Rule::EOI => continue,
-                        Rule::COMMENT => {
-                            let start = pair.as_span().start_pos().line_col().0;
-                            let end = pair.as_span().end_pos().line_col().0;
-                            codes.push(GrammarRule { is_comment: true, identifier: String::new(), modifier: String::new(), code: pair.as_str().to_string(), lines: (start, end) })
-                        }
-                        Rule::grammar_rule => codes.push(self.format_grammar_rule(pair)),
-                        Rule::WHITESPACE => continue,
-                        _ => continue,
-                    };
+    pub fn format(&self, text: &str) -> Result<String, &str> {
+        let pairs = PestParser::parse(Rule::grammar_rules, text).unwrap_or_else(|e| panic!("{}", e));
+        let mut code = String::new();
+        let mut codes = vec![];
+        for pair in pairs {
+            match pair.as_rule() {
+                Rule::EOI => continue,
+                Rule::COMMENT => {
+                    let start = pair.as_span().start_pos().line_col().0;
+                    let end = pair.as_span().end_pos().line_col().0;
+                    codes.push(GrammarRule { is_comment: true, identifier: String::new(), modifier: String::new(), code: pair.as_str().to_string(), lines: (start, end) })
                 }
-                let mut last = 0 as usize;
-                let mut group = vec![];
-                let mut groups = vec![];
-                for i in codes {
-                    let (s, e) = i.lines;
-                    if last + 1 == s {
-                        group.push(i)
-                    }
-                    else {
-                        if group.len() != 0 {
-                            groups.push(group);
-                        }
-                        group = vec![i]
-                    }
-                    last = e
-                }
-                groups.push(group);
-                for g in groups {
-                    let mut length = vec![];
-                    for r in &g {
-                        length.push(r.identifier.chars().count())
-                    }
-                    let max = length.iter().max().unwrap();
-
-                    for r in &g {
-                        code.push_str(&r.to_string(*max));
-                        code.push_str("\n");
-                    }
-                    code.push_str("\n");
-                }
-                code.to_string()
+                Rule::grammar_rule => match self.format_grammar_rule(pair) {
+                    Ok(rule) => codes.push(rule),
+                    Err(e) => return Err("e"),
+                },
+                Rule::WHITESPACE => continue,
+                _ => return Err("unreachable"),
+            };
+        }
+        let mut last = 0 as usize;
+        let mut group = vec![];
+        let mut groups = vec![];
+        for i in codes {
+            let (s, e) = i.lines;
+            if last + 1 == s {
+                group.push(i)
             }
             else {
-                String::new()
+                if group.len() != 0 {
+                    groups.push(group);
+                }
+                group = vec![i]
             }
-        });
-        result.unwrap_or(String::new())
+            last = e
+        }
+        groups.push(group);
+        for g in groups {
+            let mut length = vec![];
+            for r in &g {
+                length.push(r.identifier.chars().count())
+            }
+            let max = length.iter().max().unwrap();
+
+            for r in &g {
+                code.push_str(&r.to_string(*max));
+                code.push_str("\n");
+            }
+            code.push_str("\n");
+        }
+        return Ok(code);
     }
-    fn format_grammar_rule(&self, pairs: Pair<Rule>) -> GrammarRule {
+    fn format_grammar_rule(&self, pairs: Pair<Rule>) -> Result<GrammarRule, &str> {
         let mut code = String::new();
         let mut modifier = " ".to_string();
         let mut identifier = String::new();
@@ -110,29 +110,34 @@ impl Settings {
                 Rule::compound_atomic_modifier => modifier = pair.as_str().to_string(),
                 Rule::expression => {
                     let s = self.format_expression(pair);
-                    if start == end {
-                        code = format!("{{{}}}", s.join("|"));
-                    }
-                    else if self.choice_first {
-                        let space = std::iter::repeat(' ').take(self.indent - 2).collect::<String>();
-                        code = format!("{{\n  {}}}", indent(&s.join("\n| "), &space));
-                    }
-                    else {
-                        let space = std::iter::repeat(' ').take(self.indent).collect::<String>();
-                        code = format!("{{\n{}}}", indent(&s.join(" |\n"), &space));
+                    match s {
+                        Ok(s) => {
+                            if start == end {
+                                code = format!("{{{}}}", s.join("|"));
+                            }
+                            else if self.choice_first {
+                                let space = std::iter::repeat(' ').take(self.indent - 2).collect::<String>();
+                                code = format!("{{\n  {}}}", indent(&s.join("\n| "), &space));
+                            }
+                            else {
+                                let space = std::iter::repeat(' ').take(self.indent).collect::<String>();
+                                code = format!("{{\n{}}}", indent(&s.join(" |\n"), &space));
+                            }
+                        }
+                        Err(_) => return Err("unreachable"),
                     }
                 }
                 _ => {
                     println!("Rule:    {:?}", pair.as_rule());
                     println!("Span:    {:?}", pair.as_span());
                     println!("Text:    {}\n", pair.as_str());
-                    continue;
+                    return Err("unreachable");
                 }
             };
         }
-        return GrammarRule { is_comment: false, identifier, modifier, code, lines: (start, end) };
+        return Ok(GrammarRule { is_comment: false, identifier, modifier, code, lines: (start, end) });
     }
-    fn format_expression(&self, pairs: Pair<Rule>) -> Vec<String> {
+    fn format_expression(&self, pairs: Pair<Rule>) -> Result<Vec<String>, &str> {
         let mut code = vec![];
         let mut term = String::new();
         for pair in pairs.into_inner() {
@@ -146,14 +151,19 @@ impl Settings {
                     let joiner = format!("{0}~{0}", " ".repeat(self.sequence_space));
                     term.push_str(&joiner)
                 }
-                Rule::term => term.push_str(&self.format_term(pair)),
-                _ => continue,
+                Rule::term => match self.format_term(pair) {
+                    Ok(string) => term.push_str(&string),
+                    Err(_) => return Err("unreachable"),
+                },
+
+                _ => return Err("unreachable"),
             };
         }
         code.push(term.clone());
-        return code;
+        return Ok(code);
     }
-    fn format_term(&self, pairs: Pair<Rule>) -> String {
+
+    fn format_term(&self, pairs: Pair<Rule>) -> Result<String, &str> {
         let mut code = String::new();
         for pair in pairs.into_inner() {
             match pair.as_rule() {
@@ -169,17 +179,25 @@ impl Settings {
                 Rule::range => code.push_str(pair.as_str()),
                 Rule::expression => {
                     let e = self.format_expression(pair);
-                    let joiner = format!("{0}|{0}", " ".repeat(self.choice_space));
-                    code.push_str(&e.join(&joiner))
+                    match e {
+                        Ok(expression) => {
+                            let joiner = format!("{0}|{0}", " ".repeat(self.choice_space));
+                            code.push_str(&expression.join(&joiner))
+                        }
+                        Err(_) => return Err("unreachable"),
+                    }
                 }
-                Rule::_push => code.push_str(&self.format_term(pair)),
+                Rule::_push => match &self.format_term(pair) {
+                    Ok(string) => code.push_str(&string),
+                    Err(_) => return Err("unreachable"),
+                },
                 Rule::repeat_min => code.push_str(&format_repeat_min_max(pair)),
                 Rule::repeat_exact => code.push_str(&format_repeat_min_max(pair)),
                 Rule::repeat_min_max => code.push_str(&format_repeat_min_max(pair)),
-                _ => continue,
+                _ => return Err("unreachable!"),
             };
         }
-        return code;
+        return Ok(code);
     }
 }
 
@@ -191,7 +209,7 @@ fn format_repeat_exact(pairs: Pair<Rule>) -> String {
             Rule::opening_brace => code.push_str(pair.as_str()),
             Rule::closing_brace => code.push_str(pair.as_str()),
             Rule::number => code.push_str(pair.as_str()),
-            _ => continue,
+            _ => unreachable!(),
         };
     }
     return code;
@@ -206,7 +224,7 @@ fn format_repeat_min_max(pairs: Pair<Rule>) -> String {
             Rule::closing_brace => code.push_str(pair.as_str()),
             Rule::comma => code.push_str(", "),
             Rule::number => code.push_str(pair.as_str()),
-            _ => continue,
+            _ => unreachable!(),
         };
     }
     return code;

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -108,25 +108,22 @@ impl Settings {
                 Rule::atomic_modifier => modifier = pair.as_str().to_string(),
                 Rule::non_atomic_modifier => modifier = pair.as_str().to_string(),
                 Rule::compound_atomic_modifier => modifier = pair.as_str().to_string(),
-                Rule::expression => {
-                    let s = self.format_expression(pair);
-                    match s {
-                        Ok(s) => {
-                            if start == end {
-                                code = format!("{{{}}}", s.join("|"));
-                            }
-                            else if self.choice_first {
-                                let space = std::iter::repeat(' ').take(self.indent - 2).collect::<String>();
-                                code = format!("{{\n  {}}}", indent(&s.join("\n| "), &space));
-                            }
-                            else {
-                                let space = std::iter::repeat(' ').take(self.indent).collect::<String>();
-                                code = format!("{{\n{}}}", indent(&s.join(" |\n"), &space));
-                            }
+                Rule::expression => match self.format_expression(pair) {
+                    Ok(s) => {
+                        if start == end {
+                            code = format!("{{{}}}", s.join("|"));
                         }
-                        Err(_) => return Err("unreachable"),
+                        else if self.choice_first {
+                            let space = std::iter::repeat(' ').take(self.indent - 2).collect::<String>();
+                            code = format!("{{\n  {}}}", indent(&s.join("\n| "), &space));
+                        }
+                        else {
+                            let space = std::iter::repeat(' ').take(self.indent).collect::<String>();
+                            code = format!("{{\n{}}}", indent(&s.join(" |\n"), &space));
+                        }
                     }
-                }
+                    Err(_) => return Err("unreachable"),
+                },
                 _ => {
                     println!("Rule:    {:?}", pair.as_rule());
                     println!("Span:    {:?}", pair.as_span());

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -53,7 +53,7 @@ impl Settings {
                 }
                 Rule::grammar_rule => match self.format_grammar_rule(pair) {
                     Ok(rule) => codes.push(rule),
-                    Err(e) => return Err("e"),
+                    Err(e) => return Err("unreachable"),
                 },
                 Rule::WHITESPACE => continue,
                 _ => return Err("unreachable"),

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,53 +35,57 @@ impl Settings {
         return Ok(());
     }
     pub fn format(&self, text: &str) -> String {
-        let pairs = PestParser::parse(Rule::grammar_rules, text).unwrap_or_else(|e| panic!("{}", e));
-        let mut code = String::new();
-        let mut codes = vec![];
-        for pair in pairs {
-            match pair.as_rule() {
-                Rule::EOI => continue,
-                Rule::COMMENT => {
-                    let start = pair.as_span().start_pos().line_col().0;
-                    let end = pair.as_span().end_pos().line_col().0;
-                    codes.push(GrammarRule { is_comment: true, identifier: String::new(), modifier: String::new(), code: pair.as_str().to_string(), lines: (start, end) })
+        if let Ok(pairs) = PestParser::parse(Rule::grammar_rules, text) {
+            let mut code = String::new();
+            let mut codes = vec![];
+            for pair in pairs {
+                match pair.as_rule() {
+                    Rule::EOI => continue,
+                    Rule::COMMENT => {
+                        let start = pair.as_span().start_pos().line_col().0;
+                        let end = pair.as_span().end_pos().line_col().0;
+                        codes.push(GrammarRule { is_comment: true, identifier: String::new(), modifier: String::new(), code: pair.as_str().to_string(), lines: (start, end) })
+                    }
+                    Rule::grammar_rule => codes.push(self.format_grammar_rule(pair)),
+                    Rule::WHITESPACE => continue,
+                    _ => unreachable!(),
+                };
+            }
+            let mut last = 0 as usize;
+            let mut group = vec![];
+            let mut groups = vec![];
+            for i in codes {
+                let (s, e) = i.lines;
+                if last + 1 == s {
+                    group.push(i)
                 }
-                Rule::grammar_rule => codes.push(self.format_grammar_rule(pair)),
-                Rule::WHITESPACE => continue,
-                _ => unreachable!(),
-            };
-        }
-        let mut last = 0 as usize;
-        let mut group = vec![];
-        let mut groups = vec![];
-        for i in codes {
-            let (s, e) = i.lines;
-            if last + 1 == s {
-                group.push(i)
-            }
-            else {
-                if group.len() != 0 {
-                    groups.push(group);
+                else {
+                    if group.len() != 0 {
+                        groups.push(group);
+                    }
+                    group = vec![i]
                 }
-                group = vec![i]
+                last = e
             }
-            last = e
-        }
-        groups.push(group);
-        for g in groups {
-            let mut length = vec![];
-            for r in &g {
-                length.push(r.identifier.chars().count())
-            }
-            let max = length.iter().max().unwrap();
+            groups.push(group);
+            for g in groups {
+                let mut length = vec![];
+                for r in &g {
+                    length.push(r.identifier.chars().count())
+                }
+                let max = length.iter().max().unwrap();
 
-            for r in &g {
-                code.push_str(&r.to_string(*max));
+                for r in &g {
+                    code.push_str(&r.to_string(*max));
+                    code.push_str("\n");
+                }
                 code.push_str("\n");
             }
-            code.push_str("\n");
+            code
         }
-        return code;
+        else {
+            String::new()
+        }
     }
     fn format_grammar_rule(&self, pairs: Pair<Rule>) -> GrammarRule {
         let mut code = String::new();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,7 +7,7 @@ use std::io::Error;
 fn pest_a() -> Result<(), Error> {
     let cfg = Settings::default();
     let file = include_str!("pest.pest");
-    println!("{}", cfg.format(file));
+    println!("{}", cfg.format(file).unwrap());
     cfg.format_file("tests/pest.pest", "tests/out/pest_a.pest")
 }
 
@@ -17,7 +17,7 @@ fn pest_b() -> Result<(), Error> {
     cfg.indent = 2;
     cfg.choice_first = false;
     let file = include_str!("pest.pest");
-    println!("{}", cfg.format(file));
+    println!("{}", cfg.format(file).unwrap());
     cfg.format_file("tests/pest.pest", "tests/out/pest_b.pest")
 }
 
@@ -25,7 +25,7 @@ fn pest_b() -> Result<(), Error> {
 fn valkyrie_a() -> Result<(), Error> {
     let cfg = Settings::default();
     let file = include_str!("valkyrie.pest");
-    println!("{}", cfg.format(file));
+    println!("{}", cfg.format(file).unwrap());
     cfg.format_file("tests/valkyrie.pest", "tests/out/valkyrie_a.pest")
 }
 
@@ -35,7 +35,7 @@ fn valkyrie_b() -> Result<(), Error> {
     cfg.indent = 2;
     cfg.choice_first = false;
     let file = include_str!("valkyrie.pest");
-    println!("{}", cfg.format(file));
+    println!("{}", cfg.format(file).unwrap());
     cfg.format_file("tests/valkyrie.pest", "tests/out/valkyrie_b.pest")
 }
 
@@ -43,6 +43,6 @@ fn valkyrie_b() -> Result<(), Error> {
 fn arc_a() -> Result<(), Error> {
     let cfg = Settings::default();
     let file = include_str!("arc.pest");
-    println!("{}", cfg.format(file));
+    println!("{}", cfg.format(file).unwrap());
     cfg.format_file("tests/arc.pest", "tests/out/arc_a.pest")
 }


### PR DESCRIPTION
Dearest Reviewer,

I made a yew based formatter site (https://sbeckeriv.github.io/pest_format/) using a fork of this repo. I dont really want to maintain the the fork. The issue is that I can not figure out how to recover in yew from the unreachable calls. I tried wrapping the call in panic unwind, I tried a layer of indirection. I could not figure it out. I think the code should return a result and let the calling method figure it out. I think this will support more use cases. If anything one can add a format_or_unreachable that unwraps the format and calls unreachable. 

To be clear my use case is to try and format as you type. This does mean lots of cases where you will not be able to reach normally. 

Changes:
Update call unreachable! code to result and cascade the calls.

Thank you for your time on this project.

Dictated but not reviewed,
Becker