### PR TITLE
unreachable to return Err(PestError::Unreachable)

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -191,9 +191,9 @@ impl Settings {
                     Ok(string) => code.push_str(&string),
                     Err(_) => return Err(PestError::Unreachable),
                 },
-                Rule::repeat_min => code.push_str(&format_repeat_min_max(pair)),
-                Rule::repeat_exact => code.push_str(&format_repeat_min_max(pair)),
-                Rule::repeat_min_max => code.push_str(&format_repeat_min_max(pair)),
+                Rule::repeat_min => code.push_str(&format_repeat_min_max(pair)?),
+                Rule::repeat_exact => code.push_str(&format_repeat_min_max(pair)?),
+                Rule::repeat_min_max => code.push_str(&format_repeat_min_max(pair)?),
                 _ => return Err(PestError::Unreachable),
             };
         }
@@ -211,7 +211,6 @@ fn format_comment(pairs: Pair<Rule>) -> String {
     }
     else {
         // block comment
-        unimplemented!()
     }
     return code;
 }
@@ -230,7 +229,7 @@ fn format_repeat_exact(pairs: Pair<Rule>) -> String {
     return code;
 }
 
-fn format_repeat_min_max(pairs: Pair<Rule>) -> String {
+fn format_repeat_min_max(pairs: Pair<Rule>) -> PestResult<String> {
     let mut code = String::new();
     for pair in pairs.into_inner() {
         match pair.as_rule() {
@@ -239,8 +238,8 @@ fn format_repeat_min_max(pairs: Pair<Rule>) -> String {
             Rule::closing_brace => code.push_str(pair.as_str()),
             Rule::comma => code.push_str(", "),
             Rule::number => code.push_str(pair.as_str()),
-            _ => unreachable!(),
+            _ => Err(PestError::Unreachable),
         };
     }
-    return code;
+    return Ok(code);
 }

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -211,6 +211,7 @@ fn format_comment(pairs: Pair<Rule>) -> String {
     }
     else {
         // block comment
+        unimplemented!()
     }
     return code;
 }
@@ -238,7 +239,7 @@ fn format_repeat_min_max(pairs: Pair<Rule>) -> PestResult<String> {
             Rule::closing_brace => code.push_str(pair.as_str()),
             Rule::comma => code.push_str(", "),
             Rule::number => code.push_str(pair.as_str()),
-            _ => Err(PestError::Unreachable),
+            _ => return Err(PestError::Unreachable),
         };
     }
     return Ok(code);

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -36,7 +36,10 @@ impl Settings {
         Ok(())
     }
     pub fn format(&self, text: &str) -> PestResult<String> {
-        let pairs = PestParser::parse(Rule::grammar_rules, text).unwrap_or_else(|e| panic!("{}", e));
+        let pairs = match PestParser::parse(Rule::grammar_rules, text) {
+            Ok(pairs) => pairs,
+            Err(e) => return Err(PestError::ParseFail(e.to_string())),
+        };
         let mut code = String::new();
         let mut codes = vec![];
         for pair in pairs {

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -172,7 +172,7 @@ impl Settings {
                         match inner.as_rule() {
                             Rule::WHITESPACE => continue,
                             Rule::string => code.push_str(inner.as_str()),
-                            _ => unreachable!(),
+                            _ => return Err(PestError::Unreachable),
                         }
                     }
                 }


### PR DESCRIPTION
Dearest Reviewer,

I found another `unreachable!()` and replaced it with `return Err(PestError::Unreachable)`. I did this in the github editor and did not test this change. I believe all the unreachables should be converted to the Err. If this was intentional please let me know. 

I also moved the panic to the new num ParseFail. I could not figure out how to not use the match. 

Thank you for your time,
Dictated but not reviewed,
Becker 