### PR TITLE
Improve `modifier` alignment in `grammar_rule`.

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -21,24 +21,26 @@ impl Node {
 
 #[derive(Clone)]
 pub(crate) struct GrammarRule {
-    pub is_raw: bool,
+    /// Rule identifier
     pub identifier: String,
+    /// Modifier `!`, `@`, `_` and ` `
     pub modifier: String,
+    /// Expression code
     pub code: String,
+    /// (start_line, end_line)
     pub lines: (usize, usize),
 }
 
 impl GrammarRule {
     pub(crate) fn to_string(&self, indent: usize) -> String {
-        if self.is_raw {
-            return self.code.clone();
-        }
         let mut code = self.identifier.clone();
+
         while code.chars().count() < indent {
             code.push(' ')
         }
         code.push_str(" = ");
-        code.push_str(self.modifier.trim());
+
+        code.push_str(&self.modifier);
         code.push_str(&self.code);
 
         code

--- a/tests/fixtures/arc.expected.pest
+++ b/tests/fixtures/arc.expected.pest
@@ -8,7 +8,7 @@ statement  = _{
   | list_scope
 }
 empty_line = _{ WHITESPACE* ~ NEWLINE }
-RestOfLine = { (!NEWLINE ~ ANY)* }
+RestOfLine =  { (!NEWLINE ~ ANY)* }
 /* ==================================================================================================================== */
 dict_scope = { dict_head ~ (SEPARATOR? ~ dict_pair)* }
 dict_empty = { "{" ~ "}" }
@@ -57,17 +57,17 @@ SignedNumber = ${ Sign? ~ (Decimal | Integer) }
 Decimal      = ${ Integer ~ Dot ~ ASCII_DIGIT+ }
 DecimalBad   = ${ Integer ~ Dot | Dot ~ ASCII_DIGIT+ }
 Integer      = @{ Zero | ASCII_NONZERO_DIGIT ~ (Underline? ~ ASCII_DIGIT)* }
-Complex      = { SignedNumber ~ SYMBOL }
+Complex      =  { SignedNumber ~ SYMBOL }
 Zero         = _{ "0" }
 /* ==================================================================================================================== */
 /// #3C963C: String
 /// #98C379: StringText|StringLiteralText
-String            = { SYMBOL? ~ (StringNormal | StringLines | StringCharacter) }
-StringLines       = { (Accent ~ RestOfLine?)+ }
-StringCharacter   = { Apostrophe ~ StringLiteralText ~ Apostrophe }
-StringNormal      = { Quotation ~ StringText ~ Quotation }
-StringLiteralText = { (Escape ~ (Escape | Apostrophe) | !Apostrophe ~ ANY)* }
-StringText        = { (Escape ~ (Escape | Quotation) | !Quotation ~ ANY)* }
+String            =  { SYMBOL? ~ (StringNormal | StringLines | StringCharacter) }
+StringLines       =  { (Accent ~ RestOfLine?)+ }
+StringCharacter   =  { Apostrophe ~ StringLiteralText ~ Apostrophe }
+StringNormal      =  { Quotation ~ StringText ~ Quotation }
+StringLiteralText =  { (Escape ~ (Escape | Apostrophe) | !Apostrophe ~ ANY)* }
+StringText        =  { (Escape ~ (Escape | Quotation) | !Quotation ~ ANY)* }
 Accent            = @{ "`" }
 Apostrophe        = @{ "'" }
 Quotation         = @{ "\"" }
@@ -75,13 +75,13 @@ Escape            = @{ "\\" }
 /* ==================================================================================================================== */
 /// #61AFEF
 NameSpace = @{ Key ~ (Dot ~ Key)* }
-Key       = { String | SYMBOL | Integer }
+Key       =  { String | SYMBOL | Integer }
 SYMBOL    = @{ XID_CONTINUE+ }
 /* ==================================================================================================================== */
 // NEWLINE = @{"\r" ~ "\n"|"\r"|"\n"}
 /// Gray
-COMMENT          = { MultiLineComment | LineComment }
-WHITESPACE       = { NEWLINE | SPACE_SEPARATOR | "\t" }
+COMMENT          =  { MultiLineComment | LineComment }
+WHITESPACE       =  { NEWLINE | SPACE_SEPARATOR | "\t" }
 LineComment      = ${ "%" ~ (!NEWLINE ~ ANY)* }
 MultiLineComment = ${ "%%%" ~ (MultiLineComment | !"%%%" ~ ANY)* ~ "%%%" }
 Cite             = @{ "$" }

--- a/tests/fixtures/json.expected.pest
+++ b/tests/fixtures/json.expected.pest
@@ -10,7 +10,7 @@ pair   = { string ~ ":" ~ value }
 array  = { "[" ~ value ~ ("," ~ value)* ~ "]" | "[" ~ "]" }
 
 /* Match value */
-value  = { string | number | object | array | bool | null }
+value  =  { string | number | object | array | bool | null }
 string = @{ PUSH("\"") ~ inner ~ POP }
 inner  = @{ (!(PEEK | "\\") ~ ANY)* ~ (escape ~ inner)? }
 
@@ -23,6 +23,6 @@ unicode = @{ "u" ~ ASCII_HEX_DIGIT{4} }
 number     = @{ "-"? ~ int ~ ("." ~ ASCII_DIGIT+ ~ exp? | exp)? }
 int        = @{ "0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
 exp        = @{ ("E" | "e") ~ ("+" | "-")? ~ ASCII_DIGIT+ }
-bool       = { "true" | "false" }
-null       = { "null" }
+bool       =  { "true" | "false" }
+null       =  { "null" }
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/tests/fixtures/pest.expected.pest
+++ b/tests/fixtures/pest.expected.pest
@@ -9,28 +9,28 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 grammar_rules               = _{ SOI ~ grammar_rule+ ~ EOI }
-grammar_rule                = {
+grammar_rule                =  {
     identifier ~ assignment_operator ~ modifier? ~ opening_brace ~ expression ~ closing_brace
 }
-assignment_operator         = { "=" }
-opening_brace               = { "{" }
-closing_brace               = { "}" }
-opening_paren               = { "(" }
-closing_paren               = { ")" }
-opening_brack               = { "[" }
-closing_brack               = { "]" }
+assignment_operator         =  { "=" }
+opening_brace               =  { "{" }
+closing_brace               =  { "}" }
+opening_paren               =  { "(" }
+closing_paren               =  { ")" }
+opening_brack               =  { "[" }
+closing_brack               =  { "]" }
 modifier                    = _{
     silent_modifier
   | atomic_modifier
   | compound_atomic_modifier
   | non_atomic_modifier
 }
-silent_modifier             = { "_" }
-atomic_modifier             = { "@" }
-compound_atomic_modifier    = { "$" }
-non_atomic_modifier         = { "!" }
-expression                  = { term ~ (infix_operator ~ term)* }
-term                        = { prefix_operator* ~ node ~ postfix_operator* }
+silent_modifier             =  { "_" }
+atomic_modifier             =  { "@" }
+compound_atomic_modifier    =  { "$" }
+non_atomic_modifier         =  { "!" }
+expression                  =  { term ~ (infix_operator ~ term)* }
+term                        =  { prefix_operator* ~ node ~ postfix_operator* }
 node                        = _{ opening_paren ~ expression ~ closing_paren | terminal }
 terminal                    = _{ _push | peek_slice | identifier | string | insensitive_string | range }
 prefix_operator             = _{ positive_predicate_operator | negative_predicate_operator }
@@ -44,28 +44,28 @@ postfix_operator            = _{
   | repeat_max
   | repeat_min_max
 }
-positive_predicate_operator = { "&" }
-negative_predicate_operator = { "!" }
-sequence_operator           = { "~" }
-choice_operator             = { "|" }
-optional_operator           = { "?" }
-repeat_operator             = { "*" }
-repeat_once_operator        = { "+" }
-repeat_exact                = { opening_brace ~ number ~ closing_brace }
-repeat_min                  = { opening_brace ~ number ~ comma ~ closing_brace }
-repeat_max                  = { opening_brace ~ comma ~ number ~ closing_brace }
-repeat_min_max              = { opening_brace ~ number ~ comma ~ number ~ closing_brace }
+positive_predicate_operator =  { "&" }
+negative_predicate_operator =  { "!" }
+sequence_operator           =  { "~" }
+choice_operator             =  { "|" }
+optional_operator           =  { "?" }
+repeat_operator             =  { "*" }
+repeat_once_operator        =  { "+" }
+repeat_exact                =  { opening_brace ~ number ~ closing_brace }
+repeat_min                  =  { opening_brace ~ number ~ comma ~ closing_brace }
+repeat_max                  =  { opening_brace ~ comma ~ number ~ closing_brace }
+repeat_min_max              =  { opening_brace ~ number ~ comma ~ number ~ closing_brace }
 number                      = @{ '0'..'9'+ }
 integer                     = @{ number | "-" ~ "0"* ~ '1'..'9' ~ number? }
-comma                       = { "," }
-_push                       = { "PUSH" ~ opening_paren ~ expression ~ closing_paren }
-peek_slice                  = { "PEEK" ~ opening_brack ~ integer? ~ range_operator ~ integer? ~ closing_brack }
+comma                       =  { "," }
+_push                       =  { "PUSH" ~ opening_paren ~ expression ~ closing_paren }
+peek_slice                  =  { "PEEK" ~ opening_brack ~ integer? ~ range_operator ~ integer? ~ closing_brack }
 identifier                  = @{ !"PUSH" ~ ("_" | alpha) ~ ("_" | alpha_num)* }
 alpha                       = _{ 'a'..'z' | 'A'..'Z' }
 alpha_num                   = _{ alpha | '0'..'9' }
 string                      = ${ quote ~ inner_str ~ quote }
-insensitive_string          = { "^" ~ string }
-range                       = { character ~ range_operator ~ character }
+insensitive_string          =  { "^" ~ string }
+range                       =  { character ~ range_operator ~ character }
 character                   = ${ single_quote ~ inner_chr ~ single_quote }
 inner_str                   = @{ (!("\"" | "\\") ~ ANY)* ~ (escape ~ inner_str)? }
 inner_chr                   = @{ escape | ANY }
@@ -73,9 +73,9 @@ escape                      = @{ "\\" ~ ("\"" | "\\" | "r" | "n" | "t" | "0" | "
 code                        = @{ "x" ~ hex_digit{2} }
 unicode                     = @{ "u" ~ opening_brace ~ hex_digit{2, 6} ~ closing_brace }
 hex_digit                   = @{ '0'..'9' | 'a'..'f' | 'A'..'F' }
-quote                       = { "\"" }
-single_quote                = { "'" }
-range_operator              = { ".." }
+quote                       =  { "\"" }
+single_quote                =  { "'" }
+range_operator              =  { ".." }
 newline                     = _{ "\n" | "\r\n" }
 WHITESPACE                  = _{ " " | "\t" | newline }
 block_comment               = _{ "/*" ~ (block_comment | !"*/" ~ ANY)* ~ "*/" }

--- a/tests/fixtures/valkyrie.expected.pest
+++ b/tests/fixtures/valkyrie.expected.pest
@@ -1,5 +1,5 @@
 program   = _{ SOI ~ statement* ~ EOI }
-statement = {
+statement =  {
     emptyStatement
   | importStatement ~ eos?
   | traitStatement ~ eos?
@@ -10,13 +10,13 @@ statement = {
   | expression
 }
 /* ==================================================================================================================== */
-emptyStatement = { eos | Separate }
-eos            = { Semicolon }
+emptyStatement =  { eos | Separate }
+eos            =  { Semicolon }
 comma_or_semi  = _{ Comma | Semicolon }
 block_or_stmt  = _{ block | Set ~ statement }
 /* ==================================================================================================================== */
 // FIXME: 修复 nested using
-importStatement   = {
+importStatement   =  {
     Import ~ Dot* ~ use_alias
   | Import ~ Dot* ~ use_module_select
   | Import ~ use_module_string
@@ -24,8 +24,8 @@ importStatement   = {
 use_alias         = !{ String ~ As ~ SYMBOL | SYMBOL ~ (ModuleSplit ~ SYMBOL)* ~ As ~ SYMBOL }
 use_module_select = !{ SYMBOL ~ (ModuleSplit ~ SYMBOL)* ~ (ModuleSplit ~ (module_block | Star))? }
 use_module_string = !{ String ~ (ModuleSplit ~ (module_block | Star))? }
-module_block      = { "{" ~ module_tuple ~ (comma_or_semi? ~ module_tuple)* ~ comma_or_semi? ~ "}" }
-module_tuple      = { use_alias | use_module_select }
+module_block      =  { "{" ~ module_tuple ~ (comma_or_semi? ~ module_tuple)* ~ comma_or_semi? ~ "}" }
+module_tuple      =  { use_alias | use_module_select }
 ModuleSplit       = _{ Dot | Proportion }
 
 /// #C678DD: With|Import|As
@@ -36,7 +36,7 @@ As     = @{ "as" }
 controlFlow = _{ if_statement | for_statement }
 block       = !{ "{" ~ statement+ ~ "}" }
 /* ==================================================================================================================== */
-if_statement   = { if_nested_else | if_nested | if_single_else | if_single }
+if_statement   =  { if_nested_else | if_nested | if_single_else | if_single }
 if_single      = _{ If ~ condition ~ block }
 if_nested      = _{ If ~ condition ~ block ~ else_if_block+ }
 if_single_else = _{ If ~ condition ~ block ~ if_else_block }
@@ -60,39 +60,39 @@ Return = @{ "return" }
 Break  = @{ "break" }
 Pass   = @{ "pass" }
 /* ==================================================================================================================== */
-traitStatement      = { trait_head ~ "{" ~ traitExpression* ~ "}" }
+traitStatement      =  { trait_head ~ "{" ~ traitExpression* ~ "}" }
 trait_head          = _{ Trait ~ SYMBOL ~ classExtend? }
-traitExpression     = { interfaceFunction ~ type_hint ~ comma_or_semi? }
-interfaceFunction   = { SYMBOL ~ "(" ~ interfaceParameters? ~ ")" ~ Question? }
-interfaceParameters = { expr ~ SYMBOL ~ (Comma ~ expr ~ SYMBOL)* }
+traitExpression     =  { interfaceFunction ~ type_hint ~ comma_or_semi? }
+interfaceFunction   =  { SYMBOL ~ "(" ~ interfaceParameters? ~ ")" ~ Question? }
+interfaceParameters =  { expr ~ SYMBOL ~ (Comma ~ expr ~ SYMBOL)* }
 classExtend         = ${ "extend" }
 Trait               = @{ "trait" }
 /* ==================================================================================================================== */
-assignStatement = { Let ~ assign_terms }
+assignStatement =  { Let ~ assign_terms }
 assign_terms    = _{
     "(" ~ assign_name ~ ")" ~ type_hint? ~ block_or_stmt?
   | assign_name ~ type_hint? ~ block_or_stmt?
 }
 assign_name     = _{ assign_pair ~ (Comma ~ assign_pair)* ~ Comma? }
-assign_pair     = { (!(SYMBOL ~ (Comma | Set | Colon | Semicolon | "{" | "}" | "(" | ")" | "<" | ">")) ~ SYMBOL)* ~ Symbol }
+assign_pair     =  { (!(SYMBOL ~ (Comma | Set | Colon | Semicolon | "{" | "}" | "(" | ")" | "<" | ">")) ~ SYMBOL)* ~ Symbol }
 
 /// #C678DD
 Let = @{ "let" }
 /* ==================================================================================================================== */
-defineStatement        = { Def ~ define_terms }
+defineStatement        =  { Def ~ define_terms }
 define_terms           = _{
     assign_pair ~ parametric_types ~ define_parameter ~ type_hint? ~ parametric_terms* ~ block_or_stmt
   | assign_pair ~ define_parameter ~ type_hint? ~ parametric_types_where? ~ parametric_terms* ~ block_or_stmt
 }
-define_parameter       = {
+define_parameter       =  {
     "(" ~ ")"
 }
-parametric_terms       = {
+parametric_terms       =  {
     expr ~ Colon ~ expr ~ eos?
 }
-parametric_types       = { "<" ~ parametric_types_pair ~ (Comma ~ parametric_types_pair)* ~ ">" }
-parametric_types_pair  = { (Plus | Minus)? ~ SYMBOL }
-parametric_types_where = {
+parametric_types       =  { "<" ~ parametric_types_pair ~ (Comma ~ parametric_types_pair)* ~ ">" }
+parametric_types_pair  =  { (Plus | Minus)? ~ SYMBOL }
+parametric_types_where =  {
     Where ~ SYMBOL ~ (Comma ~ SYMBOL)* ~ eos?
 }
 
@@ -101,7 +101,7 @@ Def   = @{ "def" }
 Where = @{ "where" }
 /* ==================================================================================================================== */
 /// Orange:annotation_call
-annotation      = { annotation_call+ ~ statement }
+annotation      =  { annotation_call+ ~ statement }
 annotation_call = @{ At ~ (list | apply | Symbol) }
 /* ==================================================================================================================== */
 apply    = {
@@ -113,22 +113,22 @@ apply_kv = { SYMBOL ~ Colon ~ expr | expr }
 function_name   = { SYMBOL }
 function_module = { (namespace ~ Dot)? ~ (SYMBOL ~ Dot)* }
 /* ==================================================================================================================== */
-expression    = { expr ~ eos? }
+expression    =  { expr ~ eos? }
 expr          = !{
     trinocular
   | term ~ (Infix ~ term)*
 }
-term          = { Prefix* ~ node ~ Suffix* }
-node          = { "(" ~ expr ~ ")" | tuple | bracket_call | data }
-tuple         = { "(" ~ expr ~ (Comma ~ expr)* ~ Comma? ~ ")" }
-bracket_call  = { data ~ (slice | generic_type | apply)+ }
-bracket_apply = { Symbol ~ dict }
+term          =  { Prefix* ~ node ~ Suffix* }
+node          =  { "(" ~ expr ~ ")" | tuple | bracket_call | data }
+tuple         =  { "(" ~ expr ~ (Comma ~ expr)* ~ Comma? ~ ")" }
+bracket_call  =  { data ~ (slice | generic_type | apply)+ }
+bracket_apply =  { Symbol ~ dict }
 condition     = _{ "(" ~ expr ~ ")" | expr }
-trinocular    = {
+trinocular    =  {
     term ~ Question ~ term ~ Colon ~ term
   | term ~ If ~ term ~ Else ~ term
 }
-dot_call      = { term ~ Dot ~ (Integer | Symbol) }
+dot_call      =  { term ~ Dot ~ (Integer | Symbol) }
 /* ==================================================================================================================== */
 /// #E06C75: type_hint|generic_type|parametric_types_pair
 // type_expr = _{type_term~ TypeInfix ~type_term}
@@ -144,10 +144,10 @@ Type = @{ "type" }
 // TypeInfix = @{Or}
 /* ==================================================================================================================== */
 data        = ${ dict | list | Null | Unit | Boolean | Byte | Number | String | Symbol }
-dict        = { "{" ~ key_value? ~ (Comma ~ key_value)* ~ Comma? ~ "}" }
-list        = { "[" ~ expr? ~ (Comma ~ expr)* ~ Comma? ~ "]" }
-slice       = { "[" ~ index ~ (Comma ~ index)* ~ Comma? ~ "]" }
-index       = { index_step | index_range | expr }
+dict        =  { "{" ~ key_value? ~ (Comma ~ key_value)* ~ Comma? ~ "}" }
+list        =  { "[" ~ expr? ~ (Comma ~ expr)* ~ Comma? ~ "]" }
+slice       =  { "[" ~ index ~ (Comma ~ index)* ~ Comma? ~ "]" }
+index       =  { index_step | index_range | expr }
 key_value   = !{ key_valid ~ Colon ~ expr }
 key_valid   = !{ Integer | SYMBOL | String }
 index_range = !{ expr? ~ Colon ~ expr? }
@@ -173,16 +173,16 @@ Number     = ${ Complex | Decimal | DecimalBad | Integer }
 Decimal    = ${ Integer ~ Dot ~ ASCII_DIGIT+ }
 DecimalBad = ${ Integer ~ Dot | Dot ~ ASCII_DIGIT+ }
 Integer    = @{ Zero | ASCII_NONZERO_DIGIT ~ (Underline? ~ ASCII_DIGIT)* }
-Complex    = { (Decimal | Integer) ~ SYMBOL }
+Complex    =  { (Decimal | Integer) ~ SYMBOL }
 /* ==================================================================================================================== */
 /// #3C963C: String
 /// #98C379: StringText|StringLiteralText
 String            = ${ SYMBOL? ~ (StringNormal | StringLiteral | StringEmpty) }
-StringLiteral     = { StringStart ~ StringLiteralText ~ StringEnd }
-StringNormal      = { Quotation ~ StringText ~ Quotation }
-StringEmpty       = { Quotation{2} | Apostrophe{2} }
-StringLiteralText = { (!(Apostrophe ~ PEEK) ~ ANY)* }
-StringText        = { (Solidus ~ (Solidus | Quotation) | !Quotation ~ ANY)* }
+StringLiteral     =  { StringStart ~ StringLiteralText ~ StringEnd }
+StringNormal      =  { Quotation ~ StringText ~ Quotation }
+StringEmpty       =  { Quotation{2} | Apostrophe{2} }
+StringLiteralText =  { (!(Apostrophe ~ PEEK) ~ ANY)* }
+StringText        =  { (Solidus ~ (Solidus | Quotation) | !Quotation ~ ANY)* }
 StringStart       = @{ Apostrophe{1} ~ (Apostrophe*) }
 StringEnd         = @{ POP ~ Apostrophe{1} }
 /* ==================================================================================================================== */


### PR DESCRIPTION
Before:

```
a = { "a" }
b = ${ "a" }
c = _{ "a" }
d = !{ "a" }
e = { "a" }
```

After:

```
a =  { "a" }
b = ${ "a" }
c = _{ "a" }
d = !{ "a" }
e =  { "a" }
```