### PR TITLE
Fix first comment indent in expression.

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -94,6 +94,20 @@ mod tests {
     fn test_comment_in_expr() {
         expect_correction! {
             r#"
+            a = { // this will miss
+              "a"
+              }
+            "#,
+            r#"
+            a = {
+                // this will miss
+                "a"
+            }
+            "#
+        }
+
+        expect_correction! {
+            r#"
             //comment0
             a = { "a" // comment1
                  ~ 

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -154,8 +154,8 @@ impl Formatter<'_> {
                             code.push(' ');
                         } else {
                             code.push_str("\n  ");
-                            let mut expr_code = parts.join("\n| ");
 
+                            let mut expr_code = parts.join("\n| ");
                             // Remove leading whitespace: " |" to "|"
                             expr_code = expr_code.split('\n').map(|part| part.trim()).collect::<Vec<_>>().join("\n");
 
@@ -170,7 +170,8 @@ impl Formatter<'_> {
                     if start_line == end_line {
                         code.push(' ');
                     } else {
-                        code.push_str("\n  ");
+                        code.push('\n');
+                        code.push_str(&" ".repeat(4));
                     }
 
                     code.push_str(&comment);

--- a/tests/fixtures/bad_cases.expected.pest
+++ b/tests/fixtures/bad_cases.expected.pest
@@ -27,7 +27,7 @@ log_line2 = {
 }
 
 log_line3 = {
-  // lead comment
+    // lead comment
     "1" ~ ("2" // another comment
   | "3" // longer comment
   | "4" // final comment


### PR DESCRIPTION
Before:

```
a = {
  // comment
    "a"
  | "b"
}

```

After:

```
a = {
    // comment
    "a"
  | "b"
}
```

@tomtau 
