### PR TITLE
Ability to format specific file/dir by its path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,25 +7,27 @@ fn main() -> Result<(), Box<dyn Error>> {
     let argv: Vec<String> = std::env::args().collect();
     // Check if we have a path to format
     if argv.len() > 1 {
-        let path = &argv[1];
-        if Path::new(path).exists() {
-            if Path::new(path).is_file() {
-                if let Ok(changed) = format_file(path, path) {
-                    if changed {
-                        println!("Formatted {}", path);
+        let paths = &argv[1..];
+        for path in paths {
+            if Path::new(path).exists() {
+                if Path::new(path).is_file() {
+                    if let Ok(changed) = format_file(path, path) {
+                        if changed {
+                            println!("Formatted {}", path);
+                        }
+                    }
+                } else {
+                    let walker = build_walker(path);
+                    let files = format_directory(walker)?;
+                    if files == 0 {
+                        println!("No file has been formatted");
+                    } else {
+                        println!("Formatted {} files", files);
                     }
                 }
             } else {
-                let walker = build_walker(path);
-                let files = format_directory(walker)?;
-                if files == 0 {
-                    println!("No file has been formatted");
-                } else {
-                    println!("Formatted {} files", files);
-                }
+                println!("No such file or directory: {}", path);
             }
-        } else {
-            println!("No such file or directory: {}", path);
         }
     } else {
         // Format all files in the current directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 if let Ok(changed) = format_file(path, path) {
                     if changed {
                         println!("Formatted {}", path);
-                    } else {
-                        println!("Unchanged {}", path);
                     }
                 }
             } else {
@@ -67,8 +65,6 @@ pub fn format_directory(walker: WalkBuilder) -> Result<usize, Box<dyn Error>> {
                         if changed {
                             println!("Formatted {}", path);
                             files += 1;
-                        } else {
-                            println!("Unchanged {}", path);
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             } else {
                 let walker = build_walker(path);
                 let files = format_directory(walker)?;
-                println!("Formatted {} files", files);
+                if files == 0 {
+                    println!("No file has been formatted");
+                } else {
+                    println!("Formatted {} files", files);
+                }
             }
         } else {
             println!("No such file or directory: {}", path);
@@ -29,7 +33,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Format all files in the current directory
         let walker = build_walker(".");
         let files = format_directory(walker)?;
-        println!("Formatted {} files", files);
+        if files == 0 {
+            println!("No file has been formatted");
+        } else {
+            println!("Formatted {} files", files);
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,38 @@ use pest_fmt::{Formatter, PestResult};
 use std::{error::Error, fs, path::Path};
 use toml::Value;
 
+fn main() -> Result<(), Box<dyn Error>> {
+    let argv: Vec<String> = std::env::args().collect();
+    // Check if we have a path to format
+    if argv.len() > 1 {
+        let path = &argv[1];
+        if Path::new(path).exists() {
+            if Path::new(path).is_file() {
+                if let Ok(changed) = format_file(path, path) {
+                    if changed {
+                        println!("Formatted {}", path);
+                    } else {
+                        println!("Unchanged {}", path);
+                    }
+                }
+            } else {
+                let walker = build_walker(path);
+                let files = format_directory(walker)?;
+                println!("Formatted {} files", files);
+            }
+        } else {
+            println!("No such file or directory: {}", path);
+        }
+    } else {
+        // Format all files in the current directory
+        let walker = build_walker(".");
+        let files = format_directory(walker)?;
+        println!("Formatted {} files", files);
+    }
+
+    Ok(())
+}
+
 pub fn format_file<P: AsRef<Path>>(path_from: P, path_to: P) -> PestResult<bool> {
     let input = std::fs::read_to_string(path_from)?;
     let fmt = Formatter::new(&input);
@@ -13,34 +45,30 @@ pub fn format_file<P: AsRef<Path>>(path_from: P, path_to: P) -> PestResult<bool>
     Ok(input != output)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let walker = build_walker(".");
-
-    println!("Pest Formatter");
-    println!("-------------------------------------");
-
-    let mut count = 0;
-
+/// Format all files in the given directory.
+/// Returns the number of files that were formatted.
+pub fn format_directory(walker: WalkBuilder) -> Result<usize, Box<dyn Error>> {
+    let mut files = 0;
     for entry in walker.build() {
-        let entry = entry.unwrap();
+        let entry = entry?;
         let path = entry.path();
-
         if path.is_file() {
-            match format_file(&path, &path) {
-                Ok(changed) => {
-                    if changed {
-                        count += 1
+            if let Some(path) = path.to_str() {
+                if path.ends_with(".pest") {
+                    if let Ok(changed) = format_file(path, path) {
+                        if changed {
+                            println!("Formatted {}", path);
+                            files += 1;
+                        } else {
+                            println!("Unchanged {}", path);
+                        }
                     }
-                }
-                Err(err) => {
-                    eprintln!("Error: {} {:?}", path.display(), err)
                 }
             }
         }
     }
 
-    println!("{count} files formatted.");
-    Ok(())
+    Ok(files)
 }
 
 fn build_walker(root: &str) -> WalkBuilder {


### PR DESCRIPTION
Will fix https://github.com/pest-parser/pest-fmt/issues/21

### Changes
- Specify file or directory path, if the path is file, will format it, if its directory will format all `.pest` in it
- Print "Formatted <path>" after each file in the directory, depending on whether it was formatted or not. Also with file path