### PR TITLE
Generate shell completion scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,17 @@ pest_meta = "2.5"
 text-utils = "0.2"
 toml = "0.5"
 clap = { version = "4.4.15", features = ["derive"] }
+clap_complete = "4.5.42"
 
 [dev-dependencies]
 criterion = "0.4.0"
 indoc = "2"
 pretty_assertions = "1.3.0"
 quote = "1.0"
+
+[build-dependencies]
+clap = { version = "4.4.15", features = ["derive"] }
+clap_complete = "4.5.42"
 
 [[bin]]
 name = "pestfmt"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+include!("src/cli.rs");
+
+fn main() {
+    use std::{env, fs};
+
+    use clap::{CommandFactory, ValueEnum};
+    use clap_complete::{Shell, generate_to};
+
+    let out_dir = env::var("SHELL_COMPLETIONS_DIR").or_else(|_| env::var("OUT_DIR")).unwrap();
+
+    fs::create_dir_all(&out_dir).unwrap();
+
+    let mut cmd = Args::command();
+    for &shell in Shell::value_variants() {
+        generate_to(shell, &mut cmd, "pestfmt", &out_dir).unwrap();
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,23 @@
+use clap::{CommandFactory, Parser};
+use clap_complete::{Generator, Shell, generate};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// The file or path to format
+    #[arg(default_value = ".")]
+    pub file: Vec<String>,
+
+    #[clap(long, short, default_value = "false")]
+    pub stdin: bool,
+
+    /// Generate shell completion script
+    #[arg(long, value_enum)]
+    pub gen_completion: Option<Shell>,
+}
+
+pub fn print_completions<G: Generator>(gen: G) {
+    let mut cmd = Args::command();
+
+    generate(gen, &mut cmd, "pestfmt", &mut std::io::stdout());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,18 @@
-use ignore::{overrides::OverrideBuilder, WalkBuilder};
+mod cli;
+
+use ignore::{WalkBuilder, overrides::OverrideBuilder};
 use pest_fmt::{Formatter, PestResult};
 use std::{error::Error, fs, io::Read, path::Path};
 use toml::Value;
 
 use clap::Parser;
 
-#[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
-struct Cli {
-    /// The file or path to format
-    #[arg(default_value = ".")]
-    file: Vec<String>,
-    #[clap(long, short, default_value = "false")]
-    stdin: bool,
-}
-
 fn main() -> Result<(), Box<dyn Error>> {
-    let cli = Cli::parse();
+    let cli = cli::Args::parse();
 
-    if cli.stdin {
+    if let Some(generator) = cli.gen_completion {
+        cli::print_completions(generator);
+    } else if cli.stdin {
         let mut source = String::new();
         std::io::stdin().read_to_string(&mut source).expect("failed read source from stdin");
         println!("{}", format(&source).unwrap_or_else(|e| panic!("failed to format: {:?}", e)));


### PR DESCRIPTION
This PR adds shell completion script generation using `clap_complete`, both at build time and runtime. There is now a new command line option:
```
--gen-completion <GEN_COMPLETION>
    Generate shell completion script [possible values: bash, elvish, fish, powershell, zsh]
```
The completion scripts will also be generated in `target/debug/build/pest_fmt-xxxxxxxxxxxxxxx/out/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added shell completion script generation for command-line interface.
	- Enhanced CLI with new command-line arguments for file formatting and shell completion options.

- **Chores**
	- Updated project dependencies to support new CLI functionality. 
	- Refactored command-line argument parsing mechanism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->